### PR TITLE
Remove headers from query

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,7 +144,7 @@ The response would look something like:
     "endTimestamp": 1691721665638,
     "version": "3.3.2",
     "solution": {
-        "url": "https://httpbin.org/post?$$headers[]=Authorization:mytoken",
+        "url": "https://httpbin.org/post",
         "status": 200,
         "cookies": [],
         "userAgent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/115.0.0.0 Safari/537.36",
@@ -189,7 +189,7 @@ The response would look something like:
                             },
                             "number": 4
                         },
-                        "url": "https://httpbin.org/post?$$headers[]=Authorization:mytoken"
+                        "url": "https://httpbin.org/post"
                     }
                 </pre>
             </body>

--- a/mitm.py
+++ b/mitm.py
@@ -23,6 +23,7 @@ class FlaresolverrProxy:
 
                 [key, value] = header.split(header_split_token, 1)
                 ctx.log.info(f"Setting header {key} to {value}")
+                flow.request.headers.pop(key, None)
                 flow.request.headers[key] = value
 
     def handle_post_json(self, flow):

--- a/mitm.py
+++ b/mitm.py
@@ -23,7 +23,7 @@ class FlaresolverrProxy:
 
                 [key, value] = header.split(header_split_token, 1)
                 ctx.log.info(f"Setting header {key} to {value}")
-                flow.request.headers.pop(key, None)
+                flow.request.query.pop(key, None)
                 flow.request.headers[key] = value
 
     def handle_post_json(self, flow):

--- a/mitm.py
+++ b/mitm.py
@@ -23,8 +23,8 @@ class FlaresolverrProxy:
 
                 [key, value] = header.split(header_split_token, 1)
                 ctx.log.info(f"Setting header {key} to {value}")
-                flow.request.query.pop(key, None)
                 flow.request.headers[key] = value
+            flow.request.query.pop(header_token, None)
 
     def handle_post_json(self, flow):
         ctx.log.info("Handling post json")


### PR DESCRIPTION
Not tested. I'm not really familiar with python.

https://docs.mitmproxy.org/stable/api/mitmproxy/http.html#Headers
https://docs.mitmproxy.org/stable/api/mitmproxy/http.html#Request.query
https://docs.mitmproxy.org/stable/api/mitmproxy/coretypes/multidict.html
https://docs.python.org/3/library/collections.abc.html#collections.abc.MutableMapping